### PR TITLE
Prosody

### DIFF
--- a/gruut/const.py
+++ b/gruut/const.py
@@ -308,6 +308,7 @@ class WordNode(Node):
     text_with_ws: str = ""
     interpret_as: typing.Union[str, InterpretAs] = ""
     format: typing.Union[str, InterpretAsFormat] = ""
+    rate: str = ""
 
     number: typing.Optional[Decimal] = None
     date: typing.Optional[datetime] = None

--- a/gruut/const.py
+++ b/gruut/const.py
@@ -404,6 +404,9 @@ class Word:
     voice: str = ""
     """Voice (from SSML)"""
 
+    rate: str = ""
+    """Prosody rate from SSML"""
+
     pos: typing.Optional[str] = None
     """Part of speech (None if not set)"""
 
@@ -471,6 +474,9 @@ class Sentence:
 
     voice: str = ""
     """Voice (from SSML)"""
+
+    rate: str = ""
+    """Prosody rate (from SSML)"""
 
     words: typing.List[Word] = field(default_factory=list)
     """Words in the sentence"""

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -370,7 +370,28 @@ class TextProcessor:
                 w.text for w in sentence.words if w.is_spoken
             )
 
-            # Normalize voice
+            # Normalize rate
+            sent_rate = sentence.rate
+
+            # Get rate used across all words
+            for word in sentence.words:
+                if word.rate:
+                    if sent_rate and (sent_rate != word.rate):
+                        # Multiple rates
+                        sent_rate = ""
+                        break
+
+                    sent_rate = word.rate
+
+            if sent_rate:
+                sentence.rate = sent_rate
+
+                # Set rate on all words
+                for word in sentence.words:
+                    word.rate = sent_rate
+
+
+            # Normalize rate
             sent_voice = sentence.voice
 
             # Get voice used across all words

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -554,14 +554,14 @@ class TextProcessor:
             if voice_stack:
                 scope["voice"] = voice_stack[-1]
 
-            if prosody_stack:
-                scope["rate"] = prosody_stack[-1]
-
             scope["lang"] = current_lang
 
             if target_class is WordNode:
                 if say_as_stack:
                     scope["interpret_as"], scope["format"] = say_as_stack[-1]
+
+                if prosody_stack:
+                    scope["rate"] = prosody_stack[-1]
 
                 if word_role is not None:
                     scope["role"] = word_role

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -212,7 +212,6 @@ class TextProcessor:
                                 is_major_break=is_major_break,
                                 lang=get_lang(node.lang),
                                 voice=node.voice,
-                                rate=node.voice,
                                 pause_before_ms=word_pause_before_ms,
                                 marks_before=(
                                     word_marks_before if word_marks_before else None

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -554,14 +554,15 @@ class TextProcessor:
             if voice_stack:
                 scope["voice"] = voice_stack[-1]
 
+            if prosody_stack:
+                scope["prosody"] = prosody_stack[-1]
+
             scope["lang"] = current_lang
 
             if target_class is WordNode:
                 if say_as_stack:
                     scope["interpret_as"], scope["format"] = say_as_stack[-1]
 
-                if prosody_stack:
-                    scope["rate"] = prosody_stack[-1]
 
                 if word_role is not None:
                     scope["role"] = word_role

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -515,6 +515,9 @@ class TextProcessor:
         # [voice]
         voice_stack: typing.List[str] = []
 
+        # [rate]
+        prosody_stack: typing.List[str] = []
+
         # [(interpret_as, format)]
         say_as_stack: typing.List[typing.Tuple[str, str]] = []
 
@@ -550,6 +553,9 @@ class TextProcessor:
             scope = {}
             if voice_stack:
                 scope["voice"] = voice_stack[-1]
+
+            if prosody_stack:
+                scope["rate"] = prosody_stack[-1]
 
             scope["lang"] = current_lang
 
@@ -707,6 +713,9 @@ class TextProcessor:
                 elif end_tag == "say-as":
                     if say_as_stack:
                         say_as_stack.pop()
+                elif end_tag == "prosody":
+                    if prosody_stack:
+                        prosody_stack.pop()
                 elif end_tag == "lookup":
                     if lookup_stack:
                         lookup_stack.pop()
@@ -920,6 +929,9 @@ class TextProcessor:
                             attrib_no_namespace(elem, "format", ""),
                         )
                     )
+                elif elem_tag == "prosody":
+                    prosody_rate = attrib_no_namespace(elem, "rate", "1")
+                    prosody_stack.append(prosody_rate)
                 elif elem_tag == "sub":
                     # Sub
                     last_alias = attrib_no_namespace(elem, "alias", "")

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -174,6 +174,7 @@ class TextProcessor:
                             pos=word_node.pos if pos else None,
                             lang=get_lang(node.lang),
                             voice=node.voice,
+                            rate=node.rate,
                             pause_before_ms=word_pause_before_ms,
                             marks_before=(
                                 word_marks_before if word_marks_before else None
@@ -211,6 +212,7 @@ class TextProcessor:
                                 is_major_break=is_major_break,
                                 lang=get_lang(node.lang),
                                 voice=node.voice,
+                                rate=node.voice,
                                 pause_before_ms=word_pause_before_ms,
                                 marks_before=(
                                     word_marks_before if word_marks_before else None

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -554,15 +554,14 @@ class TextProcessor:
             if voice_stack:
                 scope["voice"] = voice_stack[-1]
 
-            if prosody_stack:
-                scope["prosody"] = prosody_stack[-1]
-
             scope["lang"] = current_lang
 
             if target_class is WordNode:
                 if say_as_stack:
                     scope["interpret_as"], scope["format"] = say_as_stack[-1]
 
+                if prosody_stack:
+                    scope["rate"] = prosody_stack[-1]
 
                 if word_role is not None:
                     scope["role"] = word_role

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -390,7 +390,7 @@ class TextProcessor:
                     word.rate = sent_rate
 
 
-            # Normalize rate
+            # Normalize voice
             sent_voice = sentence.voice
 
             # Get voice used across all words


### PR DESCRIPTION
Added support for prosody in gruut. Prosody now can be provided at a sentence level.

Example:  `<?xml version="1.0" ?><speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis " xml:lang="en-US"><prosody rate="3">The charges for shipping and handling are $<say-as interpret-as="currency">299.95</say-as>.</prosody><prosody rate="4"> Expect shipping in 2 weeks.</prosody></speak>`