### PR TITLE
and is replaced with y in es

### DIFF
--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -2428,6 +2428,8 @@ class TextProcessor:
             # Replace num2words separator with and
             num_str = num_str.replace("|", " and")
             num_str = num_str.replace(" and ", " ", num_str.count(" and ") - 1)  # Only the last "and" is retained
+            if num2words_kwargs["lang"].startswith("es"):
+                num_str.replace(" and ", " y ")
         else:
             # Remove 'zero cents' part
             num_str = num_str.split("|", maxsplit=1)[0]


### PR DESCRIPTION
"and" within the text is now replaced with "y" for Spanish sentences