### PR TITLE
Interpret as address support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Gruut is a tokenizer, text cleaner, and IPA phonemizer for 14 human languages with SSML support. It's used in text-to-speech pipelines. Python 3.6+, setuptools-based.
+
+## Commands
+
+```bash
+# Lint & type check (flake8, pylint, mypy, black --check, isort --check)
+make check
+
+# Auto-format (black + isort)
+make reformat
+
+# Run tests with coverage
+make test
+
+# Run tests directly (faster, no coverage)
+PYTHONPATH="." python -m pytest tests/
+
+# Run a single test
+PYTHONPATH="." python -m pytest tests/test_en.py::EnglishTestCase::test_pos -v
+
+# Install (creates .venv)
+make install
+```
+
+Note: `gruut-lang-*` directories must be on `PYTHONPATH` for language-specific tests (the `scripts/run-tests.sh` script handles this automatically).
+
+## Architecture
+
+### Graph-based text processing
+
+The core abstraction is a **directed graph** (NetworkX) built from input text or SSML. Processing flows through graph nodes:
+
+`SpeakNode → ParagraphNode → SentenceNode → WordNode/BreakWordNode/PunctuationWordNode`
+
+The `TextProcessor` class (`gruut/text_processor.py`, ~2900 lines) orchestrates the full pipeline: tokenization → number/date/currency verbalization → phonemization → post-processing. It uses DFS traversal over the graph to emit `Sentence` objects containing `Word` objects.
+
+### Language system
+
+`gruut/lang.py` (~3000 lines) defines `get_settings()` which returns a `TextProcessorSettings` dataclass for each language. Each language configures break characters, punctuation sets, number/date formats, and pre/post-processing callbacks.
+
+Language data (lexicon DBs, CRF models) lives in separate `gruut-lang-*` packages at the repo root. These are resolved at runtime via installed packages, `~/.config/gruut/`, or `search_dirs`.
+
+### Phonemization pipeline
+
+1. **Lexicon lookup** (`gruut/phonemize.py`): SQLite `lexicon.db` with word transforms (lowercase, strip punctuation) as fallbacks
+2. **G2P model** (`gruut/g2p.py`): CRF-based grapheme-to-phoneme for unknown words
+3. **POS tagging** (`gruut/pos.py`): CRF-based part-of-speech (English, French)
+
+All three use lazy loading (`Delayed*` wrapper classes) to defer model loading until first use.
+
+### Key data structures
+
+Defined in `gruut/const.py`:
+- `Word`: text, phonemes, POS tag, flags (is_spoken, is_punctuation, is_break), pause timings
+- `Sentence`: list of Words, text, language, voice, SSML marks
+- `TextProcessorSettings`: full language configuration (breaks, punctuation, phonemizer, G2P, POS tagger, pre/post-process hooks)
+
+### Public API
+
+```python
+from gruut import sentences
+for sentence in sentences("Hello world", lang="en-us"):
+    for word in sentence:
+        print(word.text, word.phonemes)
+```
+
+CLI entry point: `gruut/__main__.py` — outputs JSONL by default, CSV with `--csv`.
+
+### Thread safety
+
+`TextProcessor` instances are cached in thread-local storage with an `RLock` for the cache itself (`gruut/__init__.py`).
+
+## Code style
+
+- **Black** (88-char lines), **isort** (mode 3), **flake8**, **pylint**, **mypy**
+- Config in `setup.cfg`, `.pylintrc`, `mypy.ini`, `.isort.cfg`
+- Tests use `unittest.TestCase` style with pytest runner

--- a/gruut/const.py
+++ b/gruut/const.py
@@ -158,6 +158,9 @@ class InterpretAs(str, Enum):
     TIME = "time"
     """Word should be interpreted as a time on the clock"""
 
+    ADDRESS = "address"
+    """Word should be interpreted as part of a street address"""
+
     WORD = "word"
     """Interpret as regular word"""
 
@@ -651,6 +654,10 @@ class TextProcessorSettings:
 
     spell_out_words: typing.Dict[str, str] = field(default_factory=dict)
     """Written form, spoken form pairs that are applied with interpret-as="spell-out" in <say-as>"""
+
+    address_abbreviations: typing.Dict[str, str] = field(default_factory=dict)
+    """Mapping from uppercase abbreviation (without trailing period) to expanded form.
+    Used when interpret-as="address" is specified in SSML <say-as>."""
 
     # Breaks
     major_breaks: typing.Set[str] = field(default_factory=set)

--- a/gruut/lang.py
+++ b/gruut/lang.py
@@ -619,7 +619,7 @@ def get_es_settings(lang_dir=None, **settings_args) -> TextProcessorSettings:
         "end_punctuations": {'"', "”", "»", "]", ")", ">"},
         "default_currency": "EUR",
         "default_date_format": InterpretAsFormat.DATE_MDY,
-        "replacements": [("'", "'")],  # normalize apostrophe
+        "replacements": [("’", "'")],  # normalize apostrophe
         "address_abbreviations": ES_ADDRESS_ABBREVIATIONS,
         **settings_args,
     }

--- a/gruut/lang.py
+++ b/gruut/lang.py
@@ -362,6 +362,167 @@ def en_is_maybe_time(s: str) -> bool:
     return EN_MAYBE_TIME_PATTERN.match(s) is not None
 
 
+# US address abbreviations (USPS Publication 28)
+# Keys are uppercase, period-stripped forms; values are the spoken expansion.
+# For conflicts between street suffixes and state codes (CT, MT), street suffix wins.
+EN_US_ADDRESS_ABBREVIATIONS: typing.Dict[str, str] = {
+    # Directionals
+    "N": "North",
+    "S": "South",
+    "E": "East",
+    "W": "West",
+    "NE": "Northeast",
+    "NW": "Northwest",
+    "SE": "Southeast",
+    "SW": "Southwest",
+    # Street suffixes (USPS Pub 28)
+    "ST": "Street",
+    "AVE": "Avenue",
+    "BLVD": "Boulevard",
+    "DR": "Drive",
+    "LN": "Lane",
+    "RD": "Road",
+    "CT": "Court",
+    "PL": "Place",
+    "CIR": "Circle",
+    "WAY": "Way",
+    "PKWY": "Parkway",
+    "HWY": "Highway",
+    "TRL": "Trail",
+    "TER": "Terrace",
+    "TERR": "Terrace",
+    "SQ": "Square",
+    "LOOP": "Loop",
+    "CRES": "Crescent",
+    "FWY": "Freeway",
+    "EXPY": "Expressway",
+    "MT": "Mount",
+    "PT": "Point",
+    "BND": "Bend",
+    "HOLW": "Hollow",
+    "XING": "Crossing",
+    "ALY": "Alley",
+    "TPKE": "Turnpike",
+    "RTE": "Route",
+    # Unit designators
+    "APT": "Apartment",
+    "STE": "Suite",
+    "BLDG": "Building",
+    "FL": "Floor",
+    "RM": "Room",
+    "DEPT": "Department",
+    "UNIT": "Unit",
+    "LOT": "Lot",
+    "SPC": "Space",
+    "TRLR": "Trailer",
+    # US state abbreviations (excluding those that conflict with suffixes above)
+    "AL": "Alabama",
+    "AK": "Alaska",
+    "AZ": "Arizona",
+    "AR": "Arkansas",
+    "CA": "California",
+    "CO": "Colorado",
+    # CT conflicts with Court (street suffix wins)
+    "DE": "Delaware",
+    "DC": "District of Columbia",
+    "GA": "Georgia",
+    "HI": "Hawaii",
+    "ID": "Idaho",
+    "IL": "Illinois",
+    "IN": "Indiana",
+    "IA": "Iowa",
+    "KS": "Kansas",
+    "KY": "Kentucky",
+    "LA": "Louisiana",
+    "ME": "Maine",
+    "MD": "Maryland",
+    "MA": "Massachusetts",
+    "MI": "Michigan",
+    "MN": "Minnesota",
+    "MS": "Mississippi",
+    "MO": "Missouri",
+    # MT conflicts with Mount (street suffix wins)
+    "NB": "Nebraska",
+    "NV": "Nevada",
+    "NH": "New Hampshire",
+    "NJ": "New Jersey",
+    "NM": "New Mexico",
+    "NY": "New York",
+    "NC": "North Carolina",
+    "ND": "North Dakota",
+    "OH": "Ohio",
+    "OK": "Oklahoma",
+    "OR": "Oregon",
+    "PA": "Pennsylvania",
+    "RI": "Rhode Island",
+    "SC": "South Carolina",
+    "SD": "South Dakota",
+    "TN": "Tennessee",
+    "TX": "Texas",
+    "UT": "Utah",
+    "VT": "Vermont",
+    "VA": "Virginia",
+    "WA": "Washington",
+    "WV": "West Virginia",
+    "WI": "Wisconsin",
+    "WY": "Wyoming",
+    # Other
+    "PO": "Post Office",
+}
+
+# Spanish address abbreviations
+ES_ADDRESS_ABBREVIATIONS: typing.Dict[str, str] = {
+    # Street types
+    "AV": "Avenida",
+    "AVDA": "Avenida",
+    "C": "Calle",
+    "PZA": "Plaza",
+    "PSO": "Paseo",
+    "BLVD": "Bulevar",
+    "CTRA": "Carretera",
+    "CMNO": "Camino",
+    "RONDA": "Ronda",
+    # Unit designators
+    "DPTO": "Departamento",
+    "PISO": "Piso",
+    "PTA": "Puerta",
+    "ESC": "Escalera",
+    # Directionals
+    "N": "Norte",
+    "S": "Sur",
+    "E": "Este",
+    "O": "Oeste",
+}
+
+# German address abbreviations
+DE_ADDRESS_ABBREVIATIONS: typing.Dict[str, str] = {
+    "STR": "Straße",
+    "NR": "Nummer",
+    "PL": "Platz",
+    "WG": "Weg",
+    "OG": "Obergeschoss",
+    "EG": "Erdgeschoss",
+}
+
+# French address abbreviations
+FR_ADDRESS_ABBREVIATIONS: typing.Dict[str, str] = {
+    "AV": "Avenue",
+    "BD": "Boulevard",
+    "BLVD": "Boulevard",
+    "PL": "Place",
+    "R": "Rue",
+    "RTE": "Route",
+    "ALL": "Allée",
+    "IMP": "Impasse",
+    "CHE": "Chemin",
+    "APP": "Appartement",
+    "BÂT": "Bâtiment",
+    "BAT": "Bâtiment",
+    "ÉT": "Étage",
+    "ET": "Étage",
+}
+
+
 def get_en_us_settings(lang_dir=None, **settings_args) -> TextProcessorSettings:
     """Create settings for English"""
     settings_args = {
@@ -411,6 +572,7 @@ def get_en_us_settings(lang_dir=None, **settings_args) -> TextProcessorSettings:
         },
         "is_maybe_time": en_is_maybe_time,
         "is_maybe_date": en_is_maybe_date,
+        "address_abbreviations": EN_US_ADDRESS_ABBREVIATIONS,
         **settings_args,
     }
 
@@ -436,6 +598,7 @@ def get_de_settings(lang_dir=None, **settings_args) -> TextProcessorSettings:
             ("’", "'"),  # normalize apostrophe
             ("ß", "ss"),  # normalize Eszett
         ],
+        "address_abbreviations": DE_ADDRESS_ABBREVIATIONS,
         **settings_args,
     }
     return TextProcessorSettings(lang="de_DE", **settings_args)
@@ -456,7 +619,8 @@ def get_es_settings(lang_dir=None, **settings_args) -> TextProcessorSettings:
         "end_punctuations": {'"', "”", "»", "]", ")", ">"},
         "default_currency": "EUR",
         "default_date_format": InterpretAsFormat.DATE_MDY,
-        "replacements": [("’", "'")],  # normalize apostrophe
+        "replacements": [("'", "'")],  # normalize apostrophe
+        "address_abbreviations": ES_ADDRESS_ABBREVIATIONS,
         **settings_args,
     }
     return TextProcessorSettings(lang="es_ES", **settings_args)
@@ -671,8 +835,9 @@ def get_fr_settings(lang_dir=None, **settings_args) -> TextProcessorSettings:
         "end_punctuations": {'"', "”", "»", "]", ")", ">"},
         "default_currency": "EUR",
         "default_date_format": InterpretAsFormat.DATE_DMY_ORDINAL,
-        "replacements": [("’", "'")],  # normalize apostrophe
+        "replacements": [("'", "'")],  # normalize apostrophe
         "post_process_sentence": fr_post_process_sentence,
+        "address_abbreviations": FR_ADDRESS_ABBREVIATIONS,
         **settings_args,
     }
     return TextProcessorSettings(lang="fr_FR", **settings_args)

--- a/gruut/lang.py
+++ b/gruut/lang.py
@@ -835,7 +835,7 @@ def get_fr_settings(lang_dir=None, **settings_args) -> TextProcessorSettings:
         "end_punctuations": {'"', "”", "»", "]", ")", ">"},
         "default_currency": "EUR",
         "default_date_format": InterpretAsFormat.DATE_DMY_ORDINAL,
-        "replacements": [("'", "'")],  # normalize apostrophe
+        "replacements": [("’", "'")],  # normalize apostrophe
         "post_process_sentence": fr_post_process_sentence,
         "address_abbreviations": FR_ADDRESS_ABBREVIATIONS,
         **settings_args,

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -479,6 +479,7 @@ class TextProcessor:
         verbalize_currency: bool = True,
         verbalize_dates: bool = True,
         verbalize_times: bool = True,
+        verbalize_addresses: bool = True,
         max_passes: int = 5,
     ) -> typing.Tuple[GraphType, Node]:
         """
@@ -500,6 +501,7 @@ class TextProcessor:
             verbalize_currency: True if annotated currency amounts should be expanded into words
             verbalize_dates: True if annotated dates should be expanded into words
             verbalize_times: True if annotated clock times should be expanded into words
+            verbalize_addresses: True if annotated address parts should be expanded into words
 
         Returns:
             graph, root: text graph and root node
@@ -1102,6 +1104,10 @@ class TextProcessor:
                     was_changed = True
 
             # Verbalize known classes
+            if verbalize_addresses:
+                if pipeline_transform(self._verbalize_address, graph, root):
+                    was_changed = True
+
             if verbalize_dates:
                 if pipeline_transform(self._verbalize_date, graph, root):
                     was_changed = True
@@ -2457,3 +2463,104 @@ class TextProcessor:
             )
             graph.add_node(currency_word.node, data=currency_word)
             graph.add_edge(word.node, currency_word.node)
+
+    _ZIP_PATTERN = re.compile(r"^\d{5}(-\d{4})?$")
+    _TRAILING_PUNCT_PATTERN = re.compile(r"^(.*?)([.,;:!?]+)$")
+
+    def _verbalize_address(
+        self,
+        graph: GraphType,
+        node: Node,
+    ):
+        """Expand address abbreviations and handle address-specific words.
+
+        Unlike other _verbalize_* methods, this returns True when it modifies
+        a word. This is necessary because clearing interpret_as on passthrough
+        words requires a subsequent pass for number/phoneme detection.
+        """
+        if not isinstance(node, WordNode):
+            return
+
+        word = typing.cast(WordNode, node)
+        if word.interpret_as != InterpretAs.ADDRESS:
+            return
+
+        settings = self.get_settings(word.lang)
+
+        # Separate trailing punctuation (commas, periods, etc.) from the word
+        # so abbreviation lookup works, and punctuation is preserved in output.
+        trailing_punct = ""
+        base_text = word.text
+        punct_match = self._TRAILING_PUNCT_PATTERN.match(base_text)
+        if punct_match:
+            base_text = punct_match.group(1)
+            trailing_punct = punct_match.group(2)
+
+        normalized = base_text.upper()
+        expansion = settings.address_abbreviations.get(normalized)
+
+        if expansion is not None:
+            # Expand abbreviation into child word node(s)
+            first_ws, last_ws = settings.get_whitespace(word.text_with_ws)
+            expanded_str = first_ws + expansion + trailing_punct + last_ws
+
+            child_words = list(settings.split_words(expanded_str))
+            for exp_word_text in child_words:
+                exp_word_text_norm = settings.normalize_whitespace(exp_word_text)
+                if not exp_word_text_norm:
+                    continue
+
+                if not settings.keep_whitespace:
+                    exp_word_text = exp_word_text_norm
+
+                child_word = WordNode(
+                    node=len(graph),
+                    implicit=True,
+                    lang=word.lang,
+                    text=exp_word_text_norm,
+                    text_with_ws=exp_word_text,
+                )
+                graph.add_node(child_word.node, data=child_word)
+                graph.add_edge(word.node, child_word.node)
+
+            return True
+
+        # Check for ZIP code pattern (5 digits or 5+4)
+        if self._ZIP_PATTERN.match(base_text):
+            first_ws, last_ws = settings.get_whitespace(word.text_with_ws)
+            digits = [c for c in base_text if c.isdigit()]
+            last_idx = len(digits) - 1
+
+            for i, digit in enumerate(digits):
+                digit_text = digit
+                digit_text_ws = digit
+
+                if settings.keep_whitespace:
+                    if i == 0:
+                        digit_text_ws = first_ws + digit_text_ws
+                    if i == last_idx:
+                        digit_text_ws = digit_text_ws + trailing_punct + last_ws
+                    elif i < last_idx:
+                        digit_text_ws = digit_text_ws + settings.join_str
+
+                digit_word = WordNode(
+                    node=len(graph),
+                    implicit=True,
+                    lang=word.lang,
+                    text=digit_text,
+                    text_with_ws=digit_text_ws,
+                    interpret_as=InterpretAs.NUMBER,
+                    format=InterpretAsFormat.NUMBER_CARDINAL,
+                    number=Decimal(int(digit)),
+                    is_maybe_number=True,
+                )
+                graph.add_node(digit_word.node, data=digit_word)
+                graph.add_edge(word.node, digit_word.node)
+
+            return True
+
+        # Not a known abbreviation or ZIP code.
+        # Clear interpret_as so the word re-enters the normal pipeline
+        # (numbers detected on next pass, regular words phonemized).
+        word.interpret_as = ""
+        return True

--- a/tests/test_en.py
+++ b/tests/test_en.py
@@ -162,6 +162,94 @@ class EnglishTestCase(unittest.TestCase):
             [word.text for word in sentence],
         )
 
+    def test_address_abbreviation_expansion(self):
+        """Test directional and street suffix expansion in address context"""
+        text = '<say-as interpret-as="address">N Main St</say-as>'
+        sentence = next(sentences(text, lang="en_US", ssml=True))
+        words = [word.text for word in sentence if word.is_spoken]
+
+        self.assertIn("North", words)
+        self.assertIn("Street", words)
+        self.assertIn("Main", words)
+
+    def test_address_state_abbreviation(self):
+        """Test US state abbreviation expansion"""
+        text = '<say-as interpret-as="address">WA</say-as>'
+        sentence = next(sentences(text, lang="en_US", ssml=True))
+        words = [word.text for word in sentence if word.is_spoken]
+
+        self.assertEqual(["Washington"], words)
+
+    def test_address_period_stripping(self):
+        """Test that trailing periods are stripped for abbreviation matching"""
+        text = '<say-as interpret-as="address">St.</say-as>'
+        sentence = next(sentences(text, lang="en_US", ssml=True))
+        words = [word.text for word in sentence if word.is_spoken]
+
+        self.assertEqual(["Street"], words)
+
+    def test_address_zip_code(self):
+        """Test ZIP code is read digit by digit"""
+        text = '<say-as interpret-as="address">98001</say-as>'
+        sentence = next(sentences(text, lang="en_US", ssml=True))
+        words = [word.text for word in sentence if word.is_spoken]
+
+        self.assertEqual(["nine", "eight", "zero", "zero", "one"], words)
+
+    def test_address_passthrough(self):
+        """Test that non-abbreviation words pass through unchanged"""
+        text = '<say-as interpret-as="address">Redmond</say-as>'
+        sentence = next(sentences(text, lang="en_US", ssml=True))
+        words = [word.text for word in sentence if word.is_spoken]
+
+        self.assertEqual(["Redmond"], words)
+
+    def test_address_number_verbalization(self):
+        """Test that street numbers are verbalized as cardinals"""
+        text = '<say-as interpret-as="address">123</say-as>'
+        sentence = next(sentences(text, lang="en_US", ssml=True))
+        words = [word.text for word in sentence if word.is_spoken]
+
+        # Should be verbalized via normal number pipeline
+        self.assertIn("one", words)
+        self.assertIn("hundred", words)
+
+    def test_address_trailing_punctuation(self):
+        """Test that trailing punctuation (comma) is preserved after expansion"""
+        text = '<say-as interpret-as="address">St, Main</say-as>'
+        sentence = next(sentences(text, lang="en_US", ssml=True))
+        words = [word.text for word in sentence]
+
+        # "St," should expand to "Street" with comma preserved as minor break
+        self.assertIn("Street", words)
+        self.assertIn(",", words)
+        self.assertIn("Main", words)
+
+    def test_address_multi_word_expansion(self):
+        """Test state abbreviation that expands to multiple words"""
+        text = '<say-as interpret-as="address">DC</say-as>'
+        sentence = next(sentences(text, lang="en_US", ssml=True))
+        words = [word.text for word in sentence if word.is_spoken]
+
+        # DC -> District of Columbia (3 words)
+        self.assertEqual(["District", "of", "Columbia"], words)
+
+    def test_address_dr_in_address_context(self):
+        """Test Dr. expands to Drive (not Doctor) in address context"""
+        text = '<say-as interpret-as="address">Dr</say-as>'
+        sentence = next(sentences(text, lang="en_US", ssml=True))
+        words = [word.text for word in sentence if word.is_spoken]
+
+        self.assertEqual(["Drive"], words)
+
+    def test_address_unit_designator(self):
+        """Test unit designator expansion"""
+        text = '<say-as interpret-as="address">Apt</say-as>'
+        sentence = next(sentences(text, lang="en_US", ssml=True))
+        words = [word.text for word in sentence if word.is_spoken]
+
+        self.assertEqual(["Apartment"], words)
+
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
 - Adds SSML <say-as interpret-as="address"> support for street address verbalization                                    - Expands address abbreviations (directionals, street suffixes, unit designators, US state codes) and reads ZIP codes 
  digit-by-digit                                                                                                        
  - Primary support for en-US (USPS Pub 28 based), with basic dictionaries for es-ES, de-DE, and fr-FR

  Details

  How it works

  When text is wrapped in <say-as interpret-as="address">, each word is processed by a new _verbalize_address step in   
  the pipeline:

  ┌─────────────────────┬───────────────────────────────┐
  │        Input        │            Output             │
  ├─────────────────────┼───────────────────────────────┤
  │ St. / St            │ Street                        │
  ├─────────────────────┼───────────────────────────────┤
  │ N, NE, SW           │ North, Northeast, Southwest   │
  ├─────────────────────┼───────────────────────────────┤
  │ Ave, Blvd, Rd       │ Avenue, Boulevard, Road       │
  ├─────────────────────┼───────────────────────────────┤
  │ Apt, Ste            │ Apartment, Suite              │
  ├─────────────────────┼───────────────────────────────┤
  │ WA, CA, TX          │ Washington, California, Texas │
  ├─────────────────────┼───────────────────────────────┤
  │ 98001 (ZIP)         │ nine eight zero zero one      │
  ├─────────────────────┼───────────────────────────────┤
  │ 123 (street number) │ one hundred and twenty-three  │
  ├─────────────────────┼───────────────────────────────┤
  │ Main, Redmond       │ passed through unchanged      │
  └─────────────────────┴───────────────────────────────┘

  Example

  <say-as interpret-as="address">123 N Main St, Apt 4B, Redmond WA 98001</say-as>
  Produces: "one hundred and twenty-three North Main Street, Apartment four B, Redmond Washington nine eight zero zero  
  one"

  Files changed

  - gruut/const.py — ADDRESS enum value + address_abbreviations settings field
  - gruut/lang.py — Address abbreviation dictionaries for en-US, es-ES, de-DE, fr-FR
  - gruut/text_processor.py — _verbalize_address method + pipeline wiring
  - tests/test_en.py — 10 new test cases

  Known limitations

  - CT maps to Court (street suffix), not Connecticut. MT maps to Mount, not Montana. Conflicting state codes can be    
  written out in full.
  - Street numbers use standard cardinal reading ("one hundred twenty-three") rather than address-style ("one
  twenty-three") — acceptable for v1.
  - No auto-detection; requires explicit SSML <say-as> markup.

  Test plan

  - 10 new address tests pass (abbreviations, states, ZIP, periods, trailing punctuation, multi-word expansion,
  passthrough, Dr→Drive)
  - Full test suite: 100 passed, 2 pre-existing failures (ar/fa missing optional deps)
  - Manual verification on server with --force-reinstall --no-deps from branch

  🤖 Generated with https://claude.ai/claude-code