### PR TITLE
Fix prosody rate/voice dropped when sentence is fully verbalized (e.g. all numbers)

### DIFF
--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -2214,6 +2214,8 @@ class TextProcessor:
                     node=len(graph),
                     implicit=True,
                     lang=word.lang,
+                    voice=word.voice,
+                    rate=word.rate,
                     text=number_word_text_norm,
                     text_with_ws=number_word_text,
                 )
@@ -2315,6 +2317,8 @@ class TextProcessor:
                 node=len(graph),
                 implicit=True,
                 lang=word.lang,
+                voice=word.voice,
+                rate=word.rate,
                 text=date_word_text_norm,
                 text_with_ws=date_word_text,
             )
@@ -2364,6 +2368,8 @@ class TextProcessor:
                 node=len(graph),
                 implicit=True,
                 lang=word.lang,
+                voice=word.voice,
+                rate=word.rate,
                 text=time_word_text_norm,
                 text_with_ws=time_word_text,
             )
@@ -2458,6 +2464,8 @@ class TextProcessor:
                 node=len(graph),
                 implicit=True,
                 lang=word.lang,
+                voice=word.voice,
+                rate=word.rate,
                 text=currency_word_text_norm,
                 text_with_ws=currency_word_text,
             )
@@ -2517,6 +2525,8 @@ class TextProcessor:
                     node=len(graph),
                     implicit=True,
                     lang=word.lang,
+                    voice=word.voice,
+                    rate=word.rate,
                     text=exp_word_text_norm,
                     text_with_ws=exp_word_text,
                 )
@@ -2547,6 +2557,8 @@ class TextProcessor:
                     node=len(graph),
                     implicit=True,
                     lang=word.lang,
+                    voice=word.voice,
+                    rate=word.rate,
                     text=digit_text,
                     text_with_ws=digit_text_ws,
                     interpret_as=InterpretAs.NUMBER,


### PR DESCRIPTION
## Summary

Fixes a bug where SSML `<prosody rate="...">` (and `<voice>`) is silently dropped when **every** input token gets expanded by a verbalize pass — most commonly when the prosody scope contains only digits/numbers, but also pure dates, times, currency, or addresses.

### Failing input
```xml
<speak xml:lang="es-MX"><prosody rate="2.0"> 1 4 5 7 </prosody></speak>
```
Output: every word has `rate=''`.

### Working input (one non-verbalized leaf survives)
```xml
<speak xml:lang="es-MX"><prosody rate="2.0"> Hello 1 4 5 7 </prosody></speak>
```
Output: every word has `rate='2.0'`.

## Root cause

`gruut/text_processor.py` parses SSML and attaches `rate`/`voice` (from the `prosody_stack` / `voice_stack`) to each `WordNode` created during XML parsing. The verbalize pass (`_verbalize_number`, `_verbalize_date`, `_verbalize_time`, `_verbalize_currency`, `_verbalize_address`) then expands those words by creating **child** `WordNode`s — e.g. `1` → `uno`. The constructor calls only copied `lang`:

```python
number_word = WordNode(
    node=len(graph),
    implicit=True,
    lang=word.lang,           # <-- only lang was copied
    text=number_word_text_norm,
    text_with_ws=number_word_text,
)
```

The DFS that emits `Word` objects only visits leaves (`graph.out_degree == 0`). For verbalized words the leaves are the children, which had no `rate`/`voice`. The sentence-level rate-normalization loop (`process_sentence`, ~L372) propagates the parent rate across the sentence **iff** at least one leaf still carries it — which is why `Hello 1 4 5 7` worked but `1 4 5 7` did not.

## Fix

Propagate `voice` and `rate` from the parent `word` to each child `WordNode` at all six child-construction sites:

| Function | File line (post-patch) |
|---|---|
| `_verbalize_number` | text_processor.py:2213 |
| `_verbalize_date` | text_processor.py:2316 |
| `_verbalize_time` | text_processor.py:2367 |
| `_verbalize_currency` | text_processor.py:2463 |
| `_verbalize_address` (abbreviation expansion) | text_processor.py:2524 |
| `_verbalize_address` (ZIP digits) | text_processor.py:2556 |

Each site adds two lines:
```python
voice=word.voice,
rate=word.rate,
```

Net diff: **+12 lines, 1 file**. No signature changes, no new code paths, no behavior change for code that wasn't already broken.

### Out of scope
`_collapse_time` (L2083) merges multiple input words into a single new node; it has a different shape (no single parent `word` to inherit from) and is not implicated in the reported bug. Leaving it for a separate change if needed.

## Test plan

- [x] Repro: `<prosody rate="2.0"> 1 4 5 7 </prosody>` (es-MX) — every output word now has `rate='2.0'` (was `''`).
- [x] Pure big number: `<prosody rate="0.5"> 1234 </prosody>` — all five verbalized words (`mil doscientos treinta y cuatro`) get `rate='0.5'`.
- [x] Regression check: `Hello 1 4 5 7`, `1234 hello`, and no-prosody cases all behave as before.
- [x] `pytest tests/test_ssml.py tests/test_text_processor.py tests/test_golden_rules.py` — **63 passed, 0 failed**.

## Reviewer notes

- The same propagation is applied to `voice` for symmetry — it has the identical structural bug with `<voice>` wrapping pure-numbers content, even though the reported case was rate-only.
- Consider whether `role`, `interpret_as`, `format` should also propagate from parent to children. I believe **not**: those describe the parent's interpretation directives that are *consumed* by verbalization itself, so children intentionally start fresh. Happy to revisit if reviewers disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)